### PR TITLE
chore(deps): bump mill-ci-release

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -1,6 +1,6 @@
 import $ivy.`com.github.lolgab::mill-mima::0.0.13`
 import $ivy.`com.goyeau::mill-scalafix::0.2.11`
-import $ivy.`io.chris-kipp::mill-ci-release::0.1.3`
+import $ivy.`io.chris-kipp::mill-ci-release::0.1.4`
 
 import mill._
 import mill.scalalib._


### PR DESCRIPTION
This brings in by default a longer await time for the repo
to close. The last release failed because of this.
