### PR TITLE
Allow build tools to supply bridge JARs themselves

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -28,6 +28,20 @@ trait CommonPublish extends CiReleaseModule with Mima {
 
   override def mimaPreviousVersions = Seq("1.5.4")
 
+  override def mimaBinaryIssueFilters =
+    Seq(
+      ProblemFilter.exclude[DirectMissingMethodProblem](
+        "bloop.config.Config#Scala.copy"
+      ),
+      ProblemFilter.exclude[DirectMissingMethodProblem](
+        "bloop.config.Config#Scala.this"
+      ),
+      ProblemFilter.exclude[DirectMissingMethodProblem](
+        "bloop.config.Config#Scala.apply"
+      ),
+      ProblemFilter.exclude[MissingTypesProblem]("bloop.config.Config$Scala$")
+    )
+
   override def pomSettings = PomSettings(
     description = "Bloop configuration library.",
     organization = "ch.epfl.scala",

--- a/config/src/bloop/config/Config.scala
+++ b/config/src/bloop/config/Config.scala
@@ -101,7 +101,8 @@ object Config {
       options: List[String],
       jars: List[Path],
       analysis: Option[Path],
-      setup: Option[CompileSetup]
+      setup: Option[CompileSetup],
+      bridgeJars: Option[List[Path]]
   )
 
   sealed abstract class Platform(val name: String) {
@@ -350,7 +351,8 @@ object Config {
             List("-warn"),
             List(),
             Some(outAnalysisFile),
-            Some(CompileSetup.empty)
+            Some(CompileSetup.empty),
+            None
           )
         ),
         Some(Java(List("-version"))),


### PR DESCRIPTION
This change allows build tools to supply bridge JARs themselves, so that the Bloop server doesn't have to fetch them itself later on. This allows to fetch those JARs from non-standard repositories, that the Bloop server doesn't know about.


Going to open PRs against [scalacenter/bloop](https://github.com/scalacenter/bloop) and [scala-cli/bloop-core](https://github.com/scala-cli/bloop-core) for more context.