### PR TITLE
refactor: remove publishing for 2.11

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -15,13 +15,12 @@ import com.github.lolgab.mill.crossplatform._
 import com.goyeau.mill.scalafix.ScalafixModule
 import io.kipp.mill.ci.release.CiReleaseModule
 
-val scala211 = "2.11.12"
 val scala212 = "2.12.17"
 val scala213 = "2.13.10"
 
 val scalaJS1 = "1.11.0"
 
-val scalaVersions = List(scala211, scala212, scala213)
+val scalaVersions = List(scala212, scala213)
 
 trait CommonPublish extends CiReleaseModule with Mima {
 


### PR DESCRIPTION
Note that this doesn't mean you can't use Bloop with 2.11, it just means
that an application using 2.11 can't use the config library anymore to
generate the config. Seeing that everything I know of is probably on
2.13, I think we're pretty safe to drop 2.11. It'd be nice to also add
in Scala 3, but we use too old of a jsoniter version for this. We're
locked on an older version to support Java 8. However, I'm assuming
we'll change that soon as well, and then we can bump this and cross
publish to 3 as well.


Also for context what made me look into this is that the new mill-scalafix
wasn't working with 2.11 anymore.