### PR TITLE
Fix to module split-style to include packages for smallmodulesfor

### DIFF
--- a/config/src/bloop/config/Config.scala
+++ b/config/src/bloop/config/Config.scala
@@ -170,7 +170,9 @@ object Config {
   object ModuleSplitStyleJS {
     case object FewestModules extends ModuleSplitStyleJS("FewestModules")
     case object SmallestModules extends ModuleSplitStyleJS("SmallestModules")
-    case object SmallModulesFor extends ModuleSplitStyleJS("SmallModulesFor")
+    final case class SmallModulesFor(packages: List[String])
+        extends ModuleSplitStyleJS("SmallModulesFor")
+    object SmallModulesFor extends ModuleSplitStyleJS("SmallModulesFor")
     val All: List[String] =
       List(FewestModules.id, SmallestModules.id, SmallModulesFor.id)
   }

--- a/config/src/bloop/config/Config.scala
+++ b/config/src/bloop/config/Config.scala
@@ -319,7 +319,7 @@ object Config {
     final val LatestVersion = "1.4.0"
     private[bloop] val empty = File(LatestVersion, Project.empty)
 
-    private[bloop] def dummyForTests: File = {
+    private[bloop] def dummyForTests(platformType: String): File = {
       val workingDirectory = PlatformFiles.userDir
       val sourceFile = PlatformFiles.createTempFile("Foo", ".scala")
 
@@ -337,15 +337,33 @@ object Config {
       val classpath = List(scalaLibraryJar)
       val resources = Some(List(PlatformFiles.resolve(outDir, "resource1.xml")))
 
+      val jdk8Path = PlatformFiles.getPath("/usr/lib/jvm/java-8-jdk")
+      val jdk11Path = PlatformFiles.getPath("/usr/lib/jvm/java-11-jdk")
+
       val platform = {
-        val jdk8Path = PlatformFiles.getPath("/usr/lib/jvm/java-8-jdk")
-        val jdk11Path = PlatformFiles.getPath("/usr/lib/jvm/java-11-jdk")
         Platform.Jvm(
           JvmConfig(Some(jdk8Path), Nil),
           Some("module.Main"),
           Some(JvmConfig(Some(jdk11Path), Nil)),
           Some(classpath),
           resources
+        )
+      }
+
+      val platformJS = {
+        Platform.Js(
+          JsConfig(
+            "1.16.0",
+            LinkerMode.Release,
+            ModuleKindJS.ESModule,
+            false,
+            None,
+            None,
+            None,
+            List(jdk8Path),
+            Some(ModuleSplitStyleJS.SmallestModules)
+          ),
+          None
         )
       }
 
@@ -376,7 +394,11 @@ object Config {
         Some(Java(List("-version"))),
         Some(Sbt("1.1.0", Nil)),
         Some(Test(List(), TestOptions(Nil, Nil))),
-        Some(platform),
+        if (platformType == "JVM") {
+          Some(platform)
+        } else if (platformType == "JS") {
+          Some(platformJS)
+        } else None,
         Some(Resolution(Nil)),
         None,
         None

--- a/config/src/bloop/config/Config.scala
+++ b/config/src/bloop/config/Config.scala
@@ -172,7 +172,11 @@ object Config {
     case object SmallestModules extends ModuleSplitStyleJS("SmallestModules")
     final case class SmallModulesFor(packages: List[String])
         extends ModuleSplitStyleJS("SmallModulesFor")
-    object SmallModulesFor extends ModuleSplitStyleJS("SmallModulesFor")
+
+    object SmallModulesFor {
+      val id: String = SmallModulesFor(List.empty).id
+    }
+
     val All: List[String] =
       List(FewestModules.id, SmallestModules.id, SmallModulesFor.id)
   }

--- a/config/src/bloop/config/ConfigCodecs.scala
+++ b/config/src/bloop/config/ConfigCodecs.scala
@@ -146,8 +146,6 @@ object ConfigCodecs {
             out.writeVal(Config.ModuleSplitStyleJS.FewestModules.id)
           case Config.ModuleSplitStyleJS.SmallestModules =>
             out.writeVal(Config.ModuleSplitStyleJS.SmallestModules.id)
-          case Config.ModuleSplitStyleJS.SmallModulesFor =>
-            out.encodeError("Can not have SmallModulesFor without packages")
           case Config.ModuleSplitStyleJS.SmallModulesFor(packages) =>
             val style = Config.ModuleSplitStyleJS.SmallModulesFor(packages)
             out.writeVal(style.id)
@@ -169,14 +167,18 @@ object ConfigCodecs {
         val splitStyle = in.readString(null)
 
         val packages =
-          if (splitStyle == Config.ModuleSplitStyleJS.SmallModulesFor.id) {
+          if (
+            splitStyle == Config.ModuleSplitStyleJS
+              .SmallModulesFor(List.empty)
+              .id
+          ) {
             in.nextToken()
             if (in.skipToKey("packages")) {
               if (in.isNextToken('[')) {
                 in.rollbackToken()
                 codecList.decodeValue(in, Nil) match {
                   case Nil =>
-                    in.decodeError("Field package can not contain empty array")
+                    in.decodeError("Field packages can not contain empty array")
                   case packages => packages
                 }
               } else {

--- a/config/test/src/bloop/config/ConfigCodecsSpec.scala
+++ b/config/test/src/bloop/config/ConfigCodecsSpec.scala
@@ -3,14 +3,19 @@ package bloop.config
 import java.nio.charset.StandardCharsets
 
 import bloop.config.Config.File
+import com.github.plokhotnyuk.jsoniter_scala.{core => jsoniter}
 
 class ConfigCodecsSpec extends munit.FunSuite {
   import ConfigCodecsSpec._
 
   override def afterAll() = {
     val filesToDelete =
-      dummyFile.project.classpath ++ dummyFile.project.sources :+ dummyFile.project.classesDir :+ dummyFile.project.out
+      dummyFileJVM.project.classpath ++ dummyFileJVM.project.sources :+ dummyFileJVM.project.classesDir :+ dummyFileJVM.project.out
+
+    val jsFilesToDelete =
+      dummyFileJS.project.classpath ++ dummyFileJS.project.sources :+ dummyFileJS.project.classesDir :+ dummyFileJS.project.out
     filesToDelete.foreach(PlatformFiles.deleteTempFile)
+    jsFilesToDelete.foreach(PlatformFiles.deleteTempFile)
 
   }
 
@@ -37,8 +42,62 @@ class ConfigCodecsSpec extends munit.FunSuite {
 
   }
 
-  test("simple-config-jsons") {
-    parseFile(dummyFile)
+  test("simple-config-jsons-jvm") {
+    parseFile(dummyFileJVM)
+  }
+
+  test("simple-config-jsonsjs") {
+    parseFile(dummyFileJS)
+  }
+
+  test("write-module-split-style-smallestmodules") {
+
+    val config: Config.ModuleSplitStyleJS =
+      Config.ModuleSplitStyleJS.SmallestModules
+    val written = jsoniter.writeToString(config)(
+      implicitly(bloop.config.ConfigCodecs.codecModuleSplitStyleJS)
+    )
+    assertEquals(written, """{"splitStyle":"SmallestModules"}""")
+  }
+
+  test("read-module-split-style-smallestmodules") {
+
+    val config: Config.ModuleSplitStyleJS =
+      Config.ModuleSplitStyleJS.SmallestModules
+    val read = jsoniter.readFromString[Config.ModuleSplitStyleJS](
+      """{"splitStyle":"SmallestModules"}"""
+    )(
+      implicitly(bloop.config.ConfigCodecs.codecModuleSplitStyleJS)
+    )
+    assertEquals(read, config)
+  }
+
+  test("write-module-split-style-smallmodulesfor") {
+
+    val config: Config.ModuleSplitStyleJS =
+      Config.ModuleSplitStyleJS.SmallModulesFor(List("one", "two"))
+    val written = jsoniter.writeToString(config)(
+      implicitly(bloop.config.ConfigCodecs.codecModuleSplitStyleJS)
+    )
+    assertEquals(
+      written,
+      """{"splitStyle":"SmallModulesFor","packages":["one","two"]}"""
+    )
+  }
+
+  test("read-module-split-style-smallmodulesfor") {
+
+    val config: Config.ModuleSplitStyleJS =
+      Config.ModuleSplitStyleJS.SmallModulesFor(List("one", "two"))
+    val read = jsoniter.readFromString[Config.ModuleSplitStyleJS](
+      """{"splitStyle":"SmallModulesFor","packages":["one","two"]}"""
+    )(
+      implicitly(bloop.config.ConfigCodecs.codecModuleSplitStyleJS)
+    )
+    assertEquals(
+      read,
+      config
+    )
   }
 
   test("test-idea") {
@@ -77,5 +136,6 @@ class ConfigCodecsSpec extends munit.FunSuite {
 }
 
 object ConfigCodecsSpec {
-  val dummyFile = File.dummyForTests
+  val dummyFileJVM = File.dummyForTests("JVM")
+  val dummyFileJS = File.dummyForTests("JS")
 }


### PR DESCRIPTION
SmallModulesFor as it was implemented did not include the required list of packages needed for the linker configuration

I was trying to update the js-bridge in bloop-core and I noticed I had messed this up in the last PR... The smallest modules for option requires a list of packages, see: https://github.com/scala-js/scala-js/blob/61e8525eebef3b17290c900c84fea9ba91dc540e/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/ModuleSplitStyle.scala#L43.

So, I'm not sure how you'd structure this ADT in Scala 2, but I think this is an ok solution. 

something like this 
```scala
  val configOne: Config.ModuleSplitStyleJS =
    Config.ModuleSplitStyleJS.SmallModulesFor(List("one", "two"))

  val configTwo: Config.ModuleSplitStyleJS =
    Config.ModuleSplitStyleJS.SmallestModules

  val readConfigOne = jsoniter.readFromString[Config.ModuleSplitStyleJS](
    """{"splitStyle":"SmallModulesFor","packages":["one","two"]}"""
  )

  val readConfigTwo = jsoniter.readFromString[Config.ModuleSplitStyleJS](
    """{"splitStyle":"SmallestModules"}"""
  )
  println(readConfigOne)
  println(readConfigTwo)
  println(jsoniter.writeToString(configOne))
  println(jsoniter.writeToString(configTwo))
  ```
  prints
  ```shell
  SmallModulesFor(List(one, two))
SmallestModules
{"splitStyle":"SmallModulesFor","packages":["one","two"]}
{"splitStyle":"SmallestModules"}
```

this seems like an reasonable encoding to me. 
