### PR TITLE
refactor: Rename unamanagedOutputs to unamanagedInputs

### DIFF
--- a/config/src/bloop/config/Config.scala
+++ b/config/src/bloop/config/Config.scala
@@ -281,7 +281,7 @@ object Config {
       sourcesGlobs: List[SourcesGlobs],
       outputDirectory: Path,
       command: List[String],
-      @unroll unmanagedOutputs: List[Path] = Nil
+      @unroll unmanagedInputs: List[Path] = Nil
   )
 
   object SourceGenerator


### PR DESCRIPTION
I realized that outputs makes no sense