### PR TITLE
Update native config to support more configuration options

### DIFF
--- a/config/src/bloop/config/Config.scala
+++ b/config/src/bloop/config/Config.scala
@@ -228,13 +228,68 @@ object Config {
       check: Boolean,
       dump: Boolean,
       output: Option[Path],
-      @unroll buildTarget: Option[NativeBuildTarget] = None
+      @unroll buildTarget: Option[NativeBuildTarget] = None,
+      @unroll nativeLinkerReleaseMode: Option[NativeLinkerReleaseMode] = None,
+      @unroll lto: Option[NativeLTO] = None,
+      @unroll checkFatalWarnings: Boolean = false,
+      @unroll checkFeatures: Boolean = false,
+      @unroll sanitizer: Option[NativeSanitizer] = None,
+      @unroll optimize: Boolean = true,
+      @unroll useIncrementalCompilation: Boolean = true,
+      @unroll multithreading: Option[Boolean] = None,
+      @unroll embedResources: Boolean = false,
+      @unroll resourceIncludePatterns: List[String] = List("**"),
+      @unroll resourceExcludePatterns: List[String] = List.empty,
+      @unroll serviceProviders: Map[String, List[String]] = Map.empty,
+      @unroll baseName: String = "",
+      @unroll nativeOptimizerConfig: Option[NativeOptimizerConfig] = None
   ) extends PlatformConfig
+
+  case class NativeOptimizerConfig(
+      maxInlineDepth: Int,
+      maxCallerSize: Int,
+      maxCalleeSize: Int,
+      smallFunctionSize: Int
+  )
 
   object NativeConfig {
     // FORMAT: OFF
-    val empty: NativeConfig = NativeConfig("", LinkerMode.Debug, "", None, emptyPath, emptyPath, Nil, NativeOptions.empty, false, false, false, None)
+    val empty: NativeConfig = NativeConfig("", LinkerMode.Debug, "", None, emptyPath, emptyPath, Nil, NativeOptions.empty, false, false, false, None, None, None, None, false, false ,None ,true ,true, None, false, List("**"), List.empty, Map.empty, "", None)
     // FORMAT: ON
+  }
+
+  sealed abstract class NativeSanitizer(val id: String)
+  object NativeSanitizer {
+    case object AddressSanitizer extends NativeSanitizer("address")
+    case object ThreadSanitizer extends NativeSanitizer("thread")
+    case object UndefinedBehaviourSanitizer extends NativeSanitizer("undefined")
+
+    val All: List[String] =
+      List(
+        AddressSanitizer.id,
+        ThreadSanitizer.id,
+        UndefinedBehaviourSanitizer.id
+      )
+  }
+
+  sealed abstract class NativeLTO(val id: String)
+  object NativeLTO {
+    case object None extends NativeLTO("none")
+    case object Thin extends NativeLTO("none")
+    case object Full extends NativeLTO("none")
+
+    val All: List[String] =
+      List(None.id, Thin.id, Full.id)
+  }
+
+  sealed abstract class NativeLinkerReleaseMode(val id: String)
+  object NativeLinkerReleaseMode {
+    case object ReleaseFast extends NativeLinkerReleaseMode("release-fast")
+    case object ReleaseSize extends NativeLinkerReleaseMode("release-size")
+    case object ReleaseFull extends NativeLinkerReleaseMode("release-full")
+
+    val All: List[String] =
+      List(ReleaseFast.id, ReleaseSize.id, ReleaseFull.id)
   }
 
   sealed abstract class NativeBuildTarget(val id: String)

--- a/config/src/bloop/config/Config.scala
+++ b/config/src/bloop/config/Config.scala
@@ -229,21 +229,59 @@ object Config {
       dump: Boolean,
       output: Option[Path],
       @unroll buildTarget: Option[NativeBuildTarget] = None,
-      @unroll nativeLinkerReleaseMode: Option[NativeLinkerReleaseMode] = None,
-      @unroll lto: Option[NativeLTO] = None,
-      @unroll checkFatalWarnings: Boolean = false,
-      @unroll checkFeatures: Boolean = false,
       @unroll sanitizer: Option[NativeSanitizer] = None,
-      @unroll optimize: Boolean = true,
-      @unroll useIncrementalCompilation: Boolean = true,
-      @unroll multithreading: Option[Boolean] = None,
-      @unroll embedResources: Boolean = false,
-      @unroll resourceIncludePatterns: List[String] = List("**"),
-      @unroll resourceExcludePatterns: List[String] = List.empty,
+      @unroll nativeModeAndLTO: NativeModeAndLTO = NativeModeAndLTO.empty,
+      @unroll nativeFlags: NativeFlags = NativeFlags.empty,
+      @unroll nativeResourcePatterns: NativeResourcePatterns =
+        NativeResourcePatterns.empty,
       @unroll serviceProviders: Map[String, List[String]] = Map.empty,
       @unroll baseName: String = "",
       @unroll nativeOptimizerConfig: Option[NativeOptimizerConfig] = None
   ) extends PlatformConfig
+
+  object NativeConfig {
+    // FORMAT: OFF
+    val empty: NativeConfig = NativeConfig("", LinkerMode.Debug, "", None, emptyPath, emptyPath, Nil, NativeOptions.empty, false, false, false, None, None, None, NativeModeAndLTO.empty, NativeFlags.empty, NativeResourcePatterns.empty, Map.empty, "", None)
+    // FORMAT: ON
+  }
+
+  case class NativeModeAndLTO(
+      nativeLinkerReleaseMode: Option[NativeLinkerReleaseMode],
+      lto: Option[NativeLTO]
+  )
+
+  object NativeModeAndLTO {
+    def empty: NativeModeAndLTO = NativeModeAndLTO(None, None)
+  }
+  case class NativeResourcePatterns(
+      resourceIncludePatterns: List[String],
+      resourceExcludePatterns: List[String]
+  )
+
+  object NativeResourcePatterns {
+    def empty: NativeResourcePatterns =
+      NativeResourcePatterns(List("**"), List.empty)
+  }
+
+  case class NativeFlags(
+      checkFatalWarnings: Boolean,
+      checkFeatures: Boolean,
+      optimize: Boolean,
+      useIncrementalCompilation: Boolean,
+      embedResources: Boolean,
+      multithreading: Option[Boolean] = None
+  )
+
+  object NativeFlags {
+    def empty = NativeFlags(
+      checkFatalWarnings = false,
+      checkFeatures = false,
+      optimize = true,
+      useIncrementalCompilation = true,
+      embedResources = false,
+      multithreading = None
+    )
+  }
 
   case class NativeOptimizerConfig(
       maxInlineDepth: Int,
@@ -251,12 +289,6 @@ object Config {
       maxCalleeSize: Int,
       smallFunctionSize: Int
   )
-
-  object NativeConfig {
-    // FORMAT: OFF
-    val empty: NativeConfig = NativeConfig("", LinkerMode.Debug, "", None, emptyPath, emptyPath, Nil, NativeOptions.empty, false, false, false, None, None, None, None, false, false ,None ,true ,true, None, false, List("**"), List.empty, Map.empty, "", None)
-    // FORMAT: ON
-  }
 
   sealed abstract class NativeSanitizer(val id: String)
   object NativeSanitizer {

--- a/config/src/bloop/config/ConfigCodecs.scala
+++ b/config/src/bloop/config/ConfigCodecs.scala
@@ -204,6 +204,130 @@ object ConfigCodecs {
     }
   }
 
+  implicit val codecNativeLTO: JsonValueCodec[Config.NativeLTO] = {
+    new JsonValueCodec[Config.NativeLTO] {
+      val nullValue: Config.NativeLTO =
+        null.asInstanceOf[Config.NativeLTO]
+      def encodeValue(x: Config.NativeLTO, out: JsonWriter): Unit = {
+        val str = x match {
+          case Config.NativeLTO.None =>
+            Config.NativeLTO.None.id
+          case Config.NativeLTO.Thin =>
+            Config.NativeLTO.Thin.id
+          case Config.NativeLTO.Full =>
+            Config.NativeLTO.Full.id
+        }
+        out.writeVal(str)
+      }
+      def decodeValue(
+          in: JsonReader,
+          default: Config.NativeLTO
+      ): Config.NativeLTO =
+        if (in.isNextToken('"')) {
+          in.rollbackToken()
+          in.readString(null) match {
+            case Config.NativeLTO.None.id =>
+              Config.NativeLTO.None
+            case Config.NativeLTO.Thin.id =>
+              Config.NativeLTO.Thin
+            case Config.NativeLTO.Full.id =>
+              Config.NativeLTO.Full
+            case _ =>
+              in.decodeError(
+                s"Expected build target ${Config.NativeLTO.All.mkString("'", "', '", "'")}"
+              )
+          }
+        } else {
+          in.rollbackToken()
+          nullValue
+        }
+    }
+  }
+
+  implicit val codecNativeLinkerReleaseMode
+      : JsonValueCodec[Config.NativeLinkerReleaseMode] = {
+    new JsonValueCodec[Config.NativeLinkerReleaseMode] {
+      val nullValue: Config.NativeLinkerReleaseMode =
+        null.asInstanceOf[Config.NativeLinkerReleaseMode]
+      def encodeValue(
+          x: Config.NativeLinkerReleaseMode,
+          out: JsonWriter
+      ): Unit = {
+        val str = x match {
+          case Config.NativeLinkerReleaseMode.ReleaseFast =>
+            Config.NativeLinkerReleaseMode.ReleaseFast.id
+          case Config.NativeLinkerReleaseMode.ReleaseSize =>
+            Config.NativeLinkerReleaseMode.ReleaseSize.id
+          case Config.NativeLinkerReleaseMode.ReleaseFull =>
+            Config.NativeLinkerReleaseMode.ReleaseFull.id
+        }
+        out.writeVal(str)
+      }
+      def decodeValue(
+          in: JsonReader,
+          default: Config.NativeLinkerReleaseMode
+      ): Config.NativeLinkerReleaseMode =
+        if (in.isNextToken('"')) {
+          in.rollbackToken()
+          in.readString(null) match {
+            case Config.NativeLinkerReleaseMode.ReleaseFast.id =>
+              Config.NativeLinkerReleaseMode.ReleaseFast
+            case Config.NativeLinkerReleaseMode.ReleaseSize.id =>
+              Config.NativeLinkerReleaseMode.ReleaseSize
+            case Config.NativeLinkerReleaseMode.ReleaseFull.id =>
+              Config.NativeLinkerReleaseMode.ReleaseFull
+            case _ =>
+              in.decodeError(
+                s"Expected build target ${Config.NativeLinkerReleaseMode.All.mkString("'", "', '", "'")}"
+              )
+          }
+        } else {
+          in.rollbackToken()
+          nullValue
+        }
+    }
+  }
+
+  implicit val codecNativeSanitizer: JsonValueCodec[Config.NativeSanitizer] = {
+    new JsonValueCodec[Config.NativeSanitizer] {
+      val nullValue: Config.NativeSanitizer =
+        null.asInstanceOf[Config.NativeSanitizer]
+      def encodeValue(x: Config.NativeSanitizer, out: JsonWriter): Unit = {
+        val str = x match {
+          case Config.NativeSanitizer.AddressSanitizer =>
+            Config.NativeSanitizer.AddressSanitizer.id
+          case Config.NativeSanitizer.ThreadSanitizer =>
+            Config.NativeSanitizer.ThreadSanitizer.id
+          case Config.NativeSanitizer.UndefinedBehaviourSanitizer =>
+            Config.NativeSanitizer.UndefinedBehaviourSanitizer.id
+        }
+        out.writeVal(str)
+      }
+      def decodeValue(
+          in: JsonReader,
+          default: Config.NativeSanitizer
+      ): Config.NativeSanitizer =
+        if (in.isNextToken('"')) {
+          in.rollbackToken()
+          in.readString(null) match {
+            case Config.NativeSanitizer.AddressSanitizer.id =>
+              Config.NativeSanitizer.AddressSanitizer
+            case Config.NativeSanitizer.ThreadSanitizer.id =>
+              Config.NativeSanitizer.ThreadSanitizer
+            case Config.NativeSanitizer.UndefinedBehaviourSanitizer.id =>
+              Config.NativeSanitizer.UndefinedBehaviourSanitizer
+            case _ =>
+              in.decodeError(
+                s"Expected build target ${Config.NativeSanitizer.All.mkString("'", "', '", "'")}"
+              )
+          }
+        } else {
+          in.rollbackToken()
+          nullValue
+        }
+    }
+  }
+
   implicit val codecNativBuildTarget
       : JsonValueCodec[Config.NativeBuildTarget] = {
     new JsonValueCodec[Config.NativeBuildTarget] {
@@ -249,6 +373,11 @@ object ConfigCodecs {
 
   implicit val codecJsConfig: JsonValueCodec[Config.JsConfig] =
     JsonCodecMaker.makeWithRequiredCollectionFields[Config.JsConfig]
+
+  implicit val codecNativeOptimizerConfig
+      : JsonValueCodec[Config.NativeOptimizerConfig] =
+    JsonCodecMaker
+      .makeWithRequiredCollectionFields[Config.NativeOptimizerConfig]
 
   implicit val codecNativeConfig: JsonValueCodec[Config.NativeConfig] =
     JsonCodecMaker.makeWithRequiredCollectionFields[Config.NativeConfig]

--- a/config/src/bloop/config/ConfigCodecs.scala
+++ b/config/src/bloop/config/ConfigCodecs.scala
@@ -382,6 +382,19 @@ object ConfigCodecs {
   implicit val codecNativeConfig: JsonValueCodec[Config.NativeConfig] =
     JsonCodecMaker.makeWithRequiredCollectionFields[Config.NativeConfig]
 
+  implicit val codecNativeResourcePatterns
+      : JsonValueCodec[Config.NativeResourcePatterns] =
+    JsonCodecMaker
+      .makeWithRequiredCollectionFields[Config.NativeResourcePatterns]
+
+  implicit val codecNativeFlags: JsonValueCodec[Config.NativeFlags] =
+    JsonCodecMaker
+      .makeWithRequiredCollectionFields[Config.NativeFlags]
+
+  implicit val codecNativeModeAndLTO: JsonValueCodec[Config.NativeModeAndLTO] =
+    JsonCodecMaker
+      .makeWithRequiredCollectionFields[Config.NativeModeAndLTO]
+
   private case class MainClass(mainClass: Option[String])
   private implicit val codecMainClass: JsonValueCodec[MainClass] = {
     new JsonValueCodec[MainClass] {


### PR DESCRIPTION
still missing linktimeProperties, sourceLevelDebuggingConfig and semanticsConfig

These properties are missing because I don't really understand them and when I looked at how mill handles linking they don't include these options... 

I added @unroll nativeLinkerReleaseMode: Option[NativeLinkerReleaseMode] = None, as a way to preserve bincompat for LinkerMode. In bloop I configured it to default to release-fast if None and LinkerMode being Release. This also means than linking JS and Native still are similar. 

Clients can override the linkermode for SN by setting the mode in NativeLinkerReleaseMode. I figure this is a good compromise for now. 