### PR TITLE
bugfix: Switch to last jsoniter version with support for JDK 8

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -47,7 +47,7 @@ trait CommonPublish extends CiReleaseModule with Mima {
 
 trait Common extends CrossScalaModule with ScalafmtModule with ScalafixModule {
 
-  val jsoniterVersion = "2.30.14"
+  val jsoniterVersion = "2.13.5.2"
   val unrollVersion = "0.1.12"
 
   override def scalafixConfig: T[Option[Path]] = T {


### PR DESCRIPTION
Otherwise users will not be able to import projects witH JDK 8